### PR TITLE
Type Associations

### DIFF
--- a/app/models/pokemon.rb
+++ b/app/models/pokemon.rb
@@ -16,6 +16,6 @@ class Pokemon < ActiveRecord::Base
   validates :is_baby, presence: true, inclusion: { in: [true, false] }
   validates :hatch_counter, presence: true, numericality: { only_integer: true }, inclusion: { in: 1..255 }
   validates :lvl_100_exp, presence: true, numericality: { greater_than_or_equal_to: 1, only_integer: true }
-  has_many :types, through: :pokemon_types
-  has_many :pokemon_types
+  belongs_to :type_1, class_name: "Type"
+  belongs_to :type_2, class_name: "Type"
 end

--- a/app/models/type.rb
+++ b/app/models/type.rb
@@ -3,6 +3,6 @@
 class Type < ActiveRecord::Base
   validates :name, presence: true
   validates :color, presence: true
-  has_many :pokemons, through: :pokemon_types
-  has_many :pokemon_types
+  has_many :primary_pokemons, class_name: 'Pokemon', foreign_key: 'type_1_id'
+  has_many :secondary_pokemons, class_name: 'Pokemon', foreign_key: 'type_2_id'
 end

--- a/db/migrate/20161214012314_remove_pokemon_types.rb
+++ b/db/migrate/20161214012314_remove_pokemon_types.rb
@@ -1,0 +1,8 @@
+class RemovePokemonTypes < ActiveRecord::Migration
+  def change
+    drop_table :pokemon_types do |t|
+      t.belongs_to :pokemon, null: false
+      t.belongs_to :type, null: false
+    end
+  end
+end

--- a/db/migrate/20161214013335_add_types_to_pokemons.rb
+++ b/db/migrate/20161214013335_add_types_to_pokemons.rb
@@ -1,0 +1,6 @@
+class AddTypesToPokemons < ActiveRecord::Migration
+  def change
+    add_reference :pokemons, :type_1
+    add_reference :pokemons, :type_2
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161214012314) do
+ActiveRecord::Schema.define(version: 20161214013335) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -34,6 +34,8 @@ ActiveRecord::Schema.define(version: 20161214012314) do
     t.integer  "lvl_100_exp",                    null: false
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.integer  "type_1_id"
+    t.integer  "type_2_id"
   end
 
   create_table "types", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,15 +11,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161213165211) do
+ActiveRecord::Schema.define(version: 20161214012314) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
-
-  create_table "pokemon_types", force: :cascade do |t|
-    t.integer "pokemon_id", null: false
-    t.integer "type_id",    null: false
-  end
 
   create_table "pokemons", force: :cascade do |t|
     t.string   "name",                           null: false

--- a/spec/models/pokemon_spec.rb
+++ b/spec/models/pokemon_spec.rb
@@ -1,6 +1,11 @@
 require 'rails_helper'
 
 RSpec.describe Pokemon, type: :model do
+  describe 'associations' do
+    it { should belong_to(:type_1).class_name('Type') }
+    it { should belong_to(:type_2).class_name('Type') }
+  end
+
   it { should have_valid(:name).when('Gourgeist') }
   it { should_not have_valid(:name).when(nil, '') }
 

--- a/spec/models/pokemon_type_spec.rb
+++ b/spec/models/pokemon_type_spec.rb
@@ -1,9 +1,0 @@
-require 'rails_helper'
-
-describe PokemonType do
-  it { should have_valid(:pokemon_id).when(2) }
-  it { should_not have_valid(:pokemon_id).when(nil, '') }
-
-  it { should have_valid(:type_id).when(2) }
-  it { should_not have_valid(:type_id).when(nil, '') }
-end

--- a/spec/models/type_spec.rb
+++ b/spec/models/type_spec.rb
@@ -1,6 +1,17 @@
 require 'rails_helper'
 
 RSpec.describe Type, type: :model do
+  describe 'associations' do
+    it do
+      should have_many(:primary_pokemons).class_name('Pokemon')
+        .with_foreign_key('type_1_id')
+    end
+    it do
+      should have_many(:secondary_pokemons).class_name('Pokemon')
+        .with_foreign_key('type_2_id')
+    end
+  end
+
   it { should have_valid(:name).when('Ghost') }
   it { should_not have_valid(:name).when(nil, '') }
 


### PR DESCRIPTION
To make this work, I needed to drop the `pokemon_types` table, add foreign keys to `Pokemons` for `type_1` and `type_2`, and then add two associations each to the Pokemon and Type models. More description is in the extended commit messages.