### PR TITLE
Adding links from Bulbapedia to the DB

### DIFF
--- a/db/migrate/20170723205456_add_bulbapedia_to_pokemons.rb
+++ b/db/migrate/20170723205456_add_bulbapedia_to_pokemons.rb
@@ -1,0 +1,6 @@
+class AddBulbapediaToPokemons < ActiveRecord::Migration
+  def change
+    add_column(:pokemons, :bulbapedia_link, :string)
+    add_column(:pokemons, :bulbapedia_image, :string)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,31 +11,33 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170627171633) do
+ActiveRecord::Schema.define(version: 20170723205456) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "pokemons", force: :cascade do |t|
-    t.string   "name",                           null: false
-    t.string   "species",                        null: false
-    t.integer  "gen_id",                         null: false
-    t.integer  "ndex",                           null: false
-    t.float    "height",                         null: false
-    t.float    "weight",                         null: false
-    t.integer  "gender_rate",                    null: false
-    t.integer  "catch_rate",                     null: false
-    t.integer  "exp_yield",                      null: false
-    t.integer  "base_happiness",                 null: false
-    t.integer  "egg_group1",                     null: false
+    t.string   "name",                             null: false
+    t.string   "species",                          null: false
+    t.integer  "gen_id",                           null: false
+    t.integer  "ndex",                             null: false
+    t.float    "height",                           null: false
+    t.float    "weight",                           null: false
+    t.integer  "gender_rate",                      null: false
+    t.integer  "catch_rate",                       null: false
+    t.integer  "exp_yield",                        null: false
+    t.integer  "base_happiness",                   null: false
+    t.integer  "egg_group1",                       null: false
     t.integer  "egg_group2"
-    t.boolean  "is_baby",        default: false, null: false
-    t.integer  "hatch_counter",                  null: false
-    t.integer  "lvl_100_exp",                    null: false
+    t.boolean  "is_baby",          default: false, null: false
+    t.integer  "hatch_counter",                    null: false
+    t.integer  "lvl_100_exp",                      null: false
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "type_1_id"
     t.integer  "type_2_id"
+    t.string   "bulbapedia_link"
+    t.string   "bulbapedia_image"
   end
 
   create_table "types", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -25,8 +25,15 @@ created_pokemon = Pokemon.create({name: pokemon["name"],
    hatch_counter: pokemon["hatch_counter"].to_i,
    lvl_100_exp: pokemon["lvl_100_exp"].to_i,
    type_1_id: pokemon["type1_id"].to_i,
-   type_2_id: pokemon["type2_id"].to_i})
+   type_2_id: pokemon["type2_id"].to_i,
+   })
 end
+Pokemon.all.each do |pokemon|
+  ndex_formatted = "%03d" % pokemon.ndex
+  pokemon.update(bulbapedia_link: "https://bulbapedia.bulbagarden.net/wiki/#{pokemon.name}(Pok%C3%A9mon)",
+  bulbapedia_image: "https://bulbapedia.bulbagarden.net/wiki/File:#{ndex_formatted}#{pokemon.name}.png")
+end
+
 
 CSV.foreach("typefile.csv", :headers => true) do |type|
   created_types = Type.create({name: type[1]})


### PR DESCRIPTION
I feel like there's a lot of really cool information on Bulbapedia outside of the Pokedex entries here. So I added the links and images. Fortunately both followed a pattern and I was able to interpolate the names and ndex numbers to get the links and images. Though for Pokemon with multiple forms and pokedex entries, this might make things wonky.