### PR TITLE
Removing Bulbapedia Images

### DIFF
--- a/app/views/queries/easiest_to_catch.html.erb
+++ b/app/views/queries/easiest_to_catch.html.erb
@@ -9,6 +9,7 @@
     <td>Weight</td>
     <td>Type 1</td>
     <td>Type 2</td>
+    <td>Bulbapedia Link</td>
   </tr>
   <% @pokemons.each do |pokemon| %>
     <tr>
@@ -21,7 +22,10 @@
       <td><%= pokemon.type_1.name %></td>
       <% if pokemon.type_2 %>
         <td><%= pokemon.type_2.name %></td>
+      <% else %>
+        <td></td>
       <% end %>
+      <td><%= link_to(pokemon.name, pokemon.bulbapedia_link) %></td>
     </tr>
   <% end %>
 </table>

--- a/app/views/queries/find_all_pokemon_of_type_1_and_type_2.html.erb
+++ b/app/views/queries/find_all_pokemon_of_type_1_and_type_2.html.erb
@@ -6,6 +6,7 @@
     <td>National Dex</td>
     <td>Height</td>
     <td>Weight</td>
+    <td>Bulbapedia Link</td>
   </tr>
   <% @pokemons.each do |pokemon| %>
     <tr>
@@ -14,8 +15,7 @@
       <td><%= pokemon.ndex %></td>
       <td><%= pokemon.height %></td>
       <td><%= pokemon.weight %></td>
-      <td><%= link_to(@pokemon.name, @pokemon.bulbapedia_link) %></td>
-      <td><%= image_tag(@pokemon.bulbapedia_image) %></td>
+      <td><%= link_to(pokemon.name, pokemon.bulbapedia_link) %></td>
     </tr>
   <% end %>
 </table>

--- a/app/views/queries/find_all_pokemon_of_type_1_or_type_2.html.erb
+++ b/app/views/queries/find_all_pokemon_of_type_1_or_type_2.html.erb
@@ -8,8 +8,7 @@
     <td>Weight</td>
     <td>Type 1</td>
     <td>Type 2</td>
-    <td>Bulbapedia</td>
-    <td>Picture</td>
+    <td>Bulbapedia Link</td>
   </tr>
   <% @pokemons.each do |pokemon| %>
     <tr>
@@ -25,7 +24,6 @@
         <td>(None)</td>
       <% end %>
       <td><%= link_to(pokemon.name, pokemon.bulbapedia_link) %></td>
-      <td><%= image_tag(pokemon.bulbapedia_image) %></td>
     </tr>
   <% end %>
 </table>

--- a/app/views/queries/find_single_pokemon_by_name.html.erb
+++ b/app/views/queries/find_single_pokemon_by_name.html.erb
@@ -5,5 +5,4 @@
   <li>Height: <%= @pokemon.height %></li>
   <li>Weight: <%= @pokemon.weight %></li>
   <li><%= link_to(@pokemon.name, @pokemon.bulbapedia_link) %></li>
-  <li><%= image_tag(@pokemon.bulbapedia_image) %></li>
 </ul>

--- a/app/views/queries/top_10_easiest_to_catch.html.erb
+++ b/app/views/queries/top_10_easiest_to_catch.html.erb
@@ -9,8 +9,7 @@
     <td>Weight</td>
     <td>Type 1</td>
     <td>Type 2</td>
-    <td>Bulbapedia</td>
-    <td>Picture</td>
+    <td>Bulbapedia Link</td>
   </tr>
   <% @pokemons.each do |pokemon| %>
     <tr>
@@ -27,7 +26,6 @@
         <td>(None)</td>
       <% end %>
       <td><%= link_to(pokemon.name, pokemon.bulbapedia_link) %></td>
-      <td><%= image_tag(pokemon.bulbapedia_image) %></td>
     </tr>
   <% end %>
 </table>

--- a/db/migrate/20170727201356_remove_bulb_image_from_pokemon.rb
+++ b/db/migrate/20170727201356_remove_bulb_image_from_pokemon.rb
@@ -1,0 +1,8 @@
+class RemoveBulbImageFromPokemon < ActiveRecord::Migration
+  def up
+    remove_column(:pokemons, :bulbapedia_image)
+  end
+  def down
+    add_column(:pokemons, :bulbapedia_image, :string)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,33 +11,32 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170723205456) do
+ActiveRecord::Schema.define(version: 20170727201356) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "pokemons", force: :cascade do |t|
-    t.string   "name",                             null: false
-    t.string   "species",                          null: false
-    t.integer  "gen_id",                           null: false
-    t.integer  "ndex",                             null: false
-    t.float    "height",                           null: false
-    t.float    "weight",                           null: false
-    t.integer  "gender_rate",                      null: false
-    t.integer  "catch_rate",                       null: false
-    t.integer  "exp_yield",                        null: false
-    t.integer  "base_happiness",                   null: false
-    t.integer  "egg_group1",                       null: false
+    t.string   "name",                            null: false
+    t.string   "species",                         null: false
+    t.integer  "gen_id",                          null: false
+    t.integer  "ndex",                            null: false
+    t.float    "height",                          null: false
+    t.float    "weight",                          null: false
+    t.integer  "gender_rate",                     null: false
+    t.integer  "catch_rate",                      null: false
+    t.integer  "exp_yield",                       null: false
+    t.integer  "base_happiness",                  null: false
+    t.integer  "egg_group1",                      null: false
     t.integer  "egg_group2"
-    t.boolean  "is_baby",          default: false, null: false
-    t.integer  "hatch_counter",                    null: false
-    t.integer  "lvl_100_exp",                      null: false
+    t.boolean  "is_baby",         default: false, null: false
+    t.integer  "hatch_counter",                   null: false
+    t.integer  "lvl_100_exp",                     null: false
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "type_1_id"
     t.integer  "type_2_id"
     t.string   "bulbapedia_link"
-    t.string   "bulbapedia_image"
   end
 
   create_table "types", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -28,10 +28,9 @@ created_pokemon = Pokemon.create({name: pokemon["name"],
    type_2_id: pokemon["type2_id"].to_i,
    })
 end
+
 Pokemon.all.each do |pokemon|
-  ndex_formatted = "%03d" % pokemon.ndex
-  pokemon.update(bulbapedia_link: "https://bulbapedia.bulbagarden.net/wiki/#{pokemon.name}_(Pok%C3%A9mon)",
-  bulbapedia_image: "https://bulbapedia.bulbagarden.net/wiki/File:#{ndex_formatted}#{pokemon.name}.png")
+  pokemon.update(bulbapedia_link: "https://bulbapedia.bulbagarden.net/wiki/#{pokemon.name}_(Pok%C3%A9mon)")
 end
 
 


### PR DESCRIPTION
It turns out that the image links go to the page of images. The individual images don't follow an easily programable pattern. So I'm removing the bulbapedia images. I might get the sprites from the pokéapi eventually, but I'll do that in a future update.