### PR TITLE
Query #11 List eact Type and the number of pokemon with that type as …

### DIFF
--- a/app/controllers/queries_controller.rb
+++ b/app/controllers/queries_controller.rb
@@ -35,10 +35,10 @@ class QueriesController < ApplicationController
   end
 
   def easiest_type_to_catch_avg
-    type_names = ["Normal", "Fighting", "Flying", "Poison", "Ground", "Rock", "Bug", "Ghost", "Steel", "Fire", "Water", "Grass", "Electric", "Psychic", "Ice", "Dragon", "Dark"]
+    type_names = Type.pluck(:name)
     type_averages = {}
     type_names.each_with_index do |name, index|
-      type_averages[name] = Pokemon.where("type_1_id = #{index} OR type_2_id = #{index}").average("catch_rate").to_i
+      type_averages[name] = Pokemon.where("type_1_id = #{index + 1} OR type_2_id = #{index + 1}").average("catch_rate").to_i
     end
     @type_sorted = type_averages.sort_by {|key, value| value}
     @easiest_to_catch_type_name = @type_sorted.last[0]
@@ -63,6 +63,15 @@ class QueriesController < ApplicationController
   def all_not_seed_pokemon
     @pokemons = Pokemon.where.not(species: "Seed").order(:ndex)
   end
+  def number_of_primary_pokemon_of_each_type
+    total_hash = Pokemon.order(:type_1_id).group(:type_1_id).count
+    types = Type.pluck(:name)
+    #The above gets us the result we want, but this way the type names are the keys
+    @totals = {}
+    total_hash.each do |type_id, total|
+      @totals[types[type_id -1]] = total
+    end
+  end
 
   def index
     @queries = {
@@ -76,7 +85,8 @@ class QueriesController < ApplicationController
       "A random pokemon with a good catch rate" => random_pokemon_with_good_catch_rate_path,
       "Exp for 3 pokemon to reach level 100" => exp_for_3_pokemon_to_reach_lvl_100_path,
       "The first 10 pokemon of generation 2, by national dex" => first_10_pokemon_of_gen_2_by_ndex_path,
-      "All the pokemon whose species isn't seed" => all_not_seed_pokemon_path
+      "All the pokemon whose species isn't seed" => all_not_seed_pokemon_path,
+      "Number of Pokemon of with each type as primary" => number_of_primary_pokemon_of_each_type_path
     }
   end
 end

--- a/app/views/queries/number_of_primary_pokemon_of_each_type.html.erb
+++ b/app/views/queries/number_of_primary_pokemon_of_each_type.html.erb
@@ -1,0 +1,13 @@
+<h2>Number of pokemon with each type as the primary type</h2>
+<table>
+  <tr>
+    <td>Type</td>
+    <td>Total</td>
+  </tr>
+  <% @totals.each do |type, total| %>
+    <tr>
+      <td><%= type %></td>
+      <td><%= total %></td>
+    </tr>
+  <% end %>
+</table>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,4 +12,5 @@ Rails.application.routes.draw do
   get '/exp_for_3_pokemon_to_reach_lvl_100', to: 'queries#exp_for_3_pokemon_to_reach_lvl_100'
   get '/first_10_pokemon_of_gen_2_by_ndex', to: 'queries#first_10_pokemon_of_gen_2_by_ndex'
   get '/all_not_seed_pokemon', to: 'queries#all_not_seed_pokemon'
+  get '/number_of_primary_pokemon_of_each_type', to: 'queries#number_of_primary_pokemon_of_each_type'
 end


### PR DESCRIPTION
…the primary type

In the process of writing this query, I discovered an off by one error in a previous query (easiest type to catch on average). The type id was not the index of the types array, but the index plus one. The error is fixed in both queries now, and it turns out the easiest type to catch is Poison and not Ground.