### PR TITLE
Query 12: 5 random male, female, and genderless Pokemon

### DIFF
--- a/app/controllers/queries_controller.rb
+++ b/app/controllers/queries_controller.rb
@@ -73,6 +73,12 @@ class QueriesController < ApplicationController
     end
   end
 
+  def five_random_female_male_genderless
+    @female = Pokemon.where(gender_rate: 8).sample(5)
+    @male = Pokemon.where(gender_rate: 0).sample(5)
+    @genderless = Pokemon.where(gender_rate: -1).sample(5)
+  end
+
   def index
     @queries = {
       "Find a pokemon by name" => find_single_pokemon_by_name_path,
@@ -86,7 +92,8 @@ class QueriesController < ApplicationController
       "Exp for 3 pokemon to reach level 100" => exp_for_3_pokemon_to_reach_lvl_100_path,
       "The first 10 pokemon of generation 2, by national dex" => first_10_pokemon_of_gen_2_by_ndex_path,
       "All the pokemon whose species isn't seed" => all_not_seed_pokemon_path,
-      "Number of Pokemon of with each type as primary" => number_of_primary_pokemon_of_each_type_path
+      "Number of Pokemon of with each type as primary" => number_of_primary_pokemon_of_each_type_path,
+      "Five random female, male, and genderless pokemon" => five_random_female_male_genderless_path
     }
   end
 end

--- a/app/views/queries/five_random_female_male_genderless.html.erb
+++ b/app/views/queries/five_random_female_male_genderless.html.erb
@@ -1,0 +1,34 @@
+<h2>5 Random female, male, and genderless pokemon</h2>
+<table>
+  <tr><td>name</td><td>National Pokdex #</td> <td>Bulbapedia Link</td></tr>
+</table>
+<h3>Female Pokemon</h3>
+<table>
+    <% @female.each do |pokemon| %>
+      <tr>
+        <td><%= pokemon.name %></td>
+        <td><%= pokemon.ndex %></td>
+        <td><%= link_to(pokemon.name, pokemon.bulbapedia_link) %></td>
+      </tr>
+    <% end %>
+</table>
+<h3>Male Pokemon</h3>
+<table>
+    <% @male.each do |pokemon| %>
+      <tr>
+        <td><%= pokemon.name %></td>
+        <td><%= pokemon.ndex %></td>
+        <td><%= link_to(pokemon.name, pokemon.bulbapedia_link) %></td>
+      </tr>
+    <% end %>
+</table>
+<h3>Genderless Pokemon</h3>
+<table>
+    <% @genderless.each do |pokemon| %>
+      <tr>
+        <td><%= pokemon.name %></td>
+        <td><%= pokemon.ndex %></td>
+        <td><%= link_to(pokemon.name, pokemon.bulbapedia_link) %></td>
+      </tr>
+    <% end %>
+</table>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,4 +13,5 @@ Rails.application.routes.draw do
   get '/first_10_pokemon_of_gen_2_by_ndex', to: 'queries#first_10_pokemon_of_gen_2_by_ndex'
   get '/all_not_seed_pokemon', to: 'queries#all_not_seed_pokemon'
   get '/number_of_primary_pokemon_of_each_type', to: 'queries#number_of_primary_pokemon_of_each_type'
+  get '/five_random_female_male_genderless', to: 'queries#five_random_female_male_genderless'
 end


### PR DESCRIPTION
Gender rate is an integer between -1 and 8. A value between 0 and 8 represents the ratio of male to female, where 0 is 100% male and 8 is 100% female. -1 is for genderless Pokemon.

In the process of working out this query, I've found an interesting bug, which is that pokemon with multiple forms have multiple pokedex entries (which I knew) and they'll show up multiple times in the sample, even though I should be getting unique entries. I think I want to keep the multiple forms in querydex, but I'll have to do something to account for them.